### PR TITLE
Bump golang version and default tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG UBI_IMAGE=registry.access.redhat.com/ubi7/ubi-minimal:latest
-ARG GO_IMAGE=rancher/hardened-build-base:v1.16.10b7
+ARG GO_IMAGE=rancher/hardened-build-base:v1.17.7b7
 FROM ${UBI_IMAGE} as ubi
 FROM ${GO_IMAGE} as builder
 ARG ARCH="amd64"
@@ -28,14 +28,13 @@ RUN if [ "${ARCH}" == "s390x" ]; then \
 # setup containerd build
 ARG SRC="github.com/k3s-io/containerd"
 ARG PKG="github.com/containerd/containerd"
-ARG TAG="v1.4.9-k3s1"
+ARG TAG="v1.5.9-k3s1"
 RUN git clone --depth=1 https://${SRC}.git $GOPATH/src/${PKG}
 WORKDIR $GOPATH/src/${PKG}
 RUN git fetch --all --tags --prune
 RUN git checkout tags/${TAG} -b ${TAG}
 ENV GO_BUILDTAGS="apparmor,seccomp,selinux,static_build,netgo,osusergo"
 ENV GO_BUILDFLAGS="-gcflags=-trimpath=${GOPATH}/src -tags=${GO_BUILDTAGS}"
-RUN go mod edit --replace google.golang.org/grpc=google.golang.org/grpc@v1.27.1 && go mod tidy && test -d vendor && go mod vendor || true
 RUN export GO_LDFLAGS="-linkmode=external \
     -X ${PKG}/version.Version=${TAG} \
     -X ${PKG}/version.Package=${SRC} \


### PR DESCRIPTION
Also drop the `go mod edit`; this issue that this was working around is no longer present upstream in the k3s-io containerd fork.