### PR TITLE
Hardcode TZ=UTC to avoid build tag being dependent on host TZ

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ ifeq ($(ARCH),)
 ARCH=$(shell go env GOARCH)
 endif
 
-BUILD_META=-build$(shell date +%Y%m%d)
+BUILD_META=-build$(shell TZ=UTC date +%Y%m%d)
 ORG ?= rancher
 PKG ?= github.com/containerd/containerd
 SRC ?= github.com/k3s-io/containerd


### PR DESCRIPTION
Fixes failure seen in https://drone-publish.rancher.io/rancher/image-build-containerd/90/2/2 where the runners did not agree on what the proper build tag was.

Signed-off-by: Brad Davidson <brad.davidson@rancher.com>