### PR TITLE
BCI base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-ARG UBI_IMAGE=registry.access.redhat.com/ubi7/ubi-minimal:latest
+ARG BCI_IMAGE=registry.suse.com/bci/bci-base:15.3.17.20.12
 ARG GO_IMAGE=rancher/hardened-build-base:v1.17.7b7
-FROM ${UBI_IMAGE} as ubi
+FROM ${BCI_IMAGE} as bci
 FROM ${GO_IMAGE} as builder
 ARG ARCH="amd64"
 # setup required packages
@@ -55,7 +55,5 @@ RUN if [ "${ARCH}" != "s390x" ]; then \
 RUN install -s bin/* /usr/local/bin
 RUN containerd --version
 
-FROM ubi
-RUN microdnf update -y && \
-    rm -rf /var/cache/yum
+FROM bci
 COPY --from=builder /usr/local/bin/ /usr/local/bin/


### PR DESCRIPTION
This PR replaces UBI7 with BCI in the final base image. Related to https://github.com/rancher/rke2/issues/3260.