### PR TITLE
Bump golang to v1.19

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -9,7 +9,7 @@ platform:
 steps:
 - name: build
   pull: always
-  image: rancher/hardened-build-base:v1.16.10b7
+  image: rancher/hardened-build-base:v1.19.3b1
   commands:
   - make DRONE_TAG=${DRONE_TAG}
   volumes:
@@ -17,7 +17,7 @@ steps:
     path: /var/run/docker.sock
 
 - name: publish
-  image: rancher/hardened-build-base:v1.16.10b7
+  image: rancher/hardened-build-base:v1.19.3b1
   commands:
   - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
   - make DRONE_TAG=${DRONE_TAG} image-push
@@ -34,7 +34,7 @@ steps:
     - tag
 
 - name: scan
-  image: rancher/hardened-build-base:v1.16.10b7
+  image: rancher/hardened-build-base:v1.19.3b1
   commands:
   - make DRONE_TAG=${DRONE_TAG} image-scan
   volumes:
@@ -60,7 +60,7 @@ node:
 steps:
 - name: build
   pull: always
-  image: rancher/hardened-build-base:v1.16.10b7
+  image: rancher/hardened-build-base:v1.19.3b1
   commands:
   - make DRONE_TAG=${DRONE_TAG}
   volumes:
@@ -68,7 +68,7 @@ steps:
     path: /var/run/docker.sock
 
 - name: publish
-  image: rancher/hardened-build-base:v1.16.10b7
+  image: rancher/hardened-build-base:v1.19.3b1
   commands:
   - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
   - make DRONE_TAG=${DRONE_TAG} image-push

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG BCI_IMAGE=registry.suse.com/bci/bci-base:15.3.17.20.12
-ARG GO_IMAGE=rancher/hardened-build-base:v1.17.7b7
+ARG GO_IMAGE=rancher/hardened-build-base:v1.19.3b1
 FROM ${BCI_IMAGE} as bci
 FROM ${GO_IMAGE} as builder
 ARG ARCH="amd64"
@@ -28,7 +28,7 @@ RUN if [ "${ARCH}" == "s390x" ]; then \
 # setup containerd build
 ARG SRC="github.com/k3s-io/containerd"
 ARG PKG="github.com/containerd/containerd"
-ARG TAG="v1.5.9-k3s1"
+ARG TAG="v1.6.10-k3s1"
 RUN git clone --depth=1 https://${SRC}.git $GOPATH/src/${PKG}
 WORKDIR $GOPATH/src/${PKG}
 RUN git fetch --all --tags --prune

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ BUILD_META=-build$(shell TZ=UTC date +%Y%m%d)
 ORG ?= rancher
 PKG ?= github.com/containerd/containerd
 SRC ?= github.com/k3s-io/containerd
-TAG ?= v1.5.9-k3s1$(BUILD_META)
+TAG ?= v1.6.10-k3s1$(BUILD_META)
 
 ifneq ($(DRONE_TAG),)
 TAG := $(DRONE_TAG)


### PR DESCRIPTION
Containerd v1.6.10 must be built with golang v1.19

Signed-off-by: Brad Davidson <brad.davidson@rancher.com>