### PR TITLE
Fix windows binary

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -35,7 +35,7 @@ RUN export GO_LDFLAGS="\
     -X ${PKG}/version.Version=${TAG} \
     -X ${PKG}/version.Package=${SRC} \
     -X ${PKG}/version.Revision=$(git rev-parse HEAD) \
-    " \
+    " CGO_ENABLED=1 CXX=x86_64-w64-mingw32-g++ CC=x86_64-w64-mingw32-gcc \
  && go build ${GO_BUILDFLAGS} -o bin/ctr.exe ./cmd/ctr \
  && go build ${GO_BUILDFLAGS} -o bin/containerd.exe ./cmd/containerd \
  && DESTDIR=$(pwd)/bin script/setup/install-runhcs-shim

--- a/manifest.tmpl
+++ b/manifest.tmpl
@@ -8,7 +8,3 @@ manifests:
     platform:
       architecture: s390x
       os: linux
-  - image: rancher/hardened-containerd:{{build.tag}}-amd64-windows
-    platform:
-      architecture: amd64
-      os: windows


### PR DESCRIPTION
Also, remove the windows image from the manifest; having it in the manifest list doesn't get handled correctly by Docker and we can pull it by the full tag on the RKE2 side anyway.

Signed-off-by: Brad Davidson <brad.davidson@rancher.com>