### PR TITLE
Exclude non-master pushes from CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -15,6 +15,12 @@ steps:
   volumes:
   - name: docker
     path: /var/run/docker.sock
+  when:
+    ref:
+      include:
+      - refs/heads/master
+      - refs/pull/**
+      - refs/tags/*
 
 - name: publish
   image: rancher/hardened-build-base:v1.20.3b1
@@ -40,6 +46,12 @@ steps:
   volumes:
   - name: docker
     path: /var/run/docker.sock
+  when:
+    ref:
+      include:
+      - refs/heads/master
+      - refs/pull/**
+      - refs/tags/*
 
 volumes:
 - name: docker
@@ -63,6 +75,12 @@ steps:
   volumes:
   - name: docker
     path: /var/run/docker.sock
+  when:
+    ref:
+      include:
+      - refs/heads/master
+      - refs/pull/**
+      - refs/tags/*
 
 - name: publish
   image: rancher/hardened-build-base:v1.20.3b1
@@ -106,6 +124,12 @@ steps:
   volumes:
   - name: docker
     path: /var/run/docker.sock
+  when:
+    ref:
+      include:
+      - refs/heads/master
+      - refs/pull/**
+      - refs/tags/*
 
 - name: publish
   image: rancher/hardened-build-base:v1.20.3b1


### PR DESCRIPTION
This contributes to https://github.com/rancher/rke2/issues/4248

We want CI to exclude push events from dev or automated branches