### PR TITLE
Bump golang to v1.24.2b1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG BCI_IMAGE=registry.suse.com/bci/bci-base
-ARG GO_IMAGE=rancher/hardened-build-base:v1.23.3b1
+ARG GO_IMAGE=rancher/hardened-build-base:v1.24.2b1
 FROM ${BCI_IMAGE} as bci
 FROM ${GO_IMAGE} as builder
 ARG GOOS="linux"

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -1,5 +1,5 @@
 ARG BCI_IMAGE=registry.suse.com/bci/bci-base
-ARG GO_IMAGE=rancher/hardened-build-base:v1.23.3b1
+ARG GO_IMAGE=rancher/hardened-build-base:v1.24.2b1
 FROM ${BCI_IMAGE} as bci
 FROM ${GO_IMAGE} as builder
 ARG ARCH="amd64"


### PR DESCRIPTION
Newer 2.x releases require golang 1.24