### PR TITLE
Update values.yaml to have github repo/owner info

### DIFF
--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -3,3 +3,6 @@ github:
   email: "41898282+github-actions[bot]@users.noreply.github.com"
   username: "UPDATECLI_GITHUB_ACTOR"
   token: "UPDATECLI_GITHUB_TOKEN"
+  repository: "image-build-containerd"
+  branch: "master"
+  owner: "rancher"


### PR DESCRIPTION
This fixes the current error on the updatecli workflow runs where it is not finding the owner/repo values. 