### PR TITLE
Bump hardened-build-base to v1.26.5b1 for Go CVE fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG BCI_IMAGE=registry.suse.com/bci/bci-base
-ARG GO_IMAGE=rancher/hardened-build-base:v1.26.4b1
+ARG GO_IMAGE=rancher/hardened-build-base:v1.26.5b1
 FROM ${BCI_IMAGE} AS bci
 FROM ${GO_IMAGE} AS builder
 ARG GOOS="linux"

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -1,5 +1,5 @@
 ARG BCI_IMAGE=registry.suse.com/bci/bci-base
-ARG GO_IMAGE=rancher/hardened-build-base:v1.26.4b1
+ARG GO_IMAGE=rancher/hardened-build-base:v1.26.5b1
 FROM ${BCI_IMAGE} AS bci
 FROM ${GO_IMAGE} AS builder
 ARG ARCH="amd64"


### PR DESCRIPTION
Bumps `rancher/hardened-build-base` to pick up the latest Go CVE fix from the freshly cut hardened-build-base release. Patch bump only (stays on the same Go minor line).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>