### PR TITLE
Add grpc go-mod-override for GHSA-hrxh-6v49-42gf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,8 @@ RUN git clone --depth=1 https://${SRC}.git $GOPATH/src/${PKG}
 WORKDIR $GOPATH/src/${PKG}
 RUN git fetch --tags --depth=1 origin ${TAG}
 RUN git checkout tags/${TAG} -b ${TAG}
+COPY go-mod-overrides ./go-mod-overrides
+RUN go-mod-overrides.sh ./go-mod-overrides
 RUN GOPKG=$(grep '^module ' go.mod | awk '{print $2}'); \
     export GO_LDFLAGS="-linkmode=external \
     -X ${GOPKG}/version.Version=${TAG} \

--- a/go-mod-overrides
+++ b/go-mod-overrides
@@ -1,0 +1,3 @@
+# google.golang.org/grpc: GHSA-hrxh-6v49-42gf (xDS RBAC auth bypass, HTTP/2 Rapid Reset DoS).
+# Drop once upstream requires google.golang.org/grpc >= v1.82.1.
+-replace google.golang.org/grpc=google.golang.org/grpc@v1.82.1


### PR DESCRIPTION
Adds a `go-mod-overrides` file pinning `google.golang.org/grpc` to **v1.82.1** to remediate **GHSA-hrxh-6v49-42gf** (xDS RBAC auth bypass, HTTP/2 Rapid Reset DoS), and wires it into the Dockerfile via the shared `go-mod-overrides.sh` script (same pattern as sibling image-build repos, e.g. rancher/image-build-external-snapshotter#16).

The binaries build from the root module, so the root replace applies directly. Verified locally: after the override, `go mod tidy && go mod vendor` succeed and the built binary links `google.golang.org/grpc v1.82.1`.

Drop once upstream requires `google.golang.org/grpc >= v1.82.1`.