### PR TITLE
Move from bci-base to bci-micro, bump to 16.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
-ARG BCI_IMAGE=registry.suse.com/bci/bci-base
+ARG BCI_IMAGE=registry.suse.com/bci/bci-micro:16.0
 ARG GO_IMAGE=rancher/hardened-build-base:v1.26.7b2
-FROM ${BCI_IMAGE} AS bci
 FROM ${GO_IMAGE} AS builder
 ARG GOOS="linux"
 ARG TARGETARCH
@@ -61,5 +60,5 @@ RUN if [ "${TARGETARCH}" = "amd64" ]; then \
 RUN install -s bin/* /usr/local/bin
 RUN containerd --version
 
-FROM bci
+FROM ${BCI_IMAGE}
 COPY --from=builder /usr/local/bin/ /usr/local/bin/

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -1,6 +1,5 @@
-ARG BCI_IMAGE=registry.suse.com/bci/bci-base
+ARG BCI_IMAGE=registry.suse.com/bci/bci-micro:16.0
 ARG GO_IMAGE=rancher/hardened-build-base:v1.26.7b2
-FROM ${BCI_IMAGE} AS bci
 FROM ${GO_IMAGE} AS builder
 ARG ARCH="amd64"
 ARG GOOS="windows"
@@ -37,5 +36,5 @@ RUN export CGO_ENABLED=1 CXX=x86_64-w64-mingw32-g++ CC=x86_64-w64-mingw32-gcc &&
     install -s bin/* /usr/local/bin && \
     strings /usr/local/bin/containerd.exe | grep -F "${TAG}"
 
-FROM bci
+FROM ${BCI_IMAGE}
 COPY --from=builder /usr/local/bin/ /usr/local/bin/


### PR DESCRIPTION
Interum step over https://github.com/rancher/image-build-containerd/pull/42, still retains `/sh` and other debug accessible packages, greatly reduced footprint compared to `bci-base`.

Signed-off-by: Derek Nola <derek.nola@suse.com>